### PR TITLE
Delete機能追加

### DIFF
--- a/src/main/java/com/task/lecture9/controller/VinylController.java
+++ b/src/main/java/com/task/lecture9/controller/VinylController.java
@@ -9,6 +9,7 @@ import com.task.lecture9.service.VinylServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -72,6 +73,15 @@ public class VinylController {
                 updateForm.getReleaseYear());
 
         var vinyl = vinylService.update(id, vinylDto);
+
+        return ResponseEntity.ok(vinyl);
+    }
+
+    @DeleteMapping("/vinyls/{id}")
+    public ResponseEntity<Map<String, String>> delete(
+            @PathVariable("id") Integer id) {
+
+        var vinyl = vinylService.delete(id);
 
         return ResponseEntity.ok(vinyl);
     }

--- a/src/main/java/com/task/lecture9/controller/VinylController.java
+++ b/src/main/java/com/task/lecture9/controller/VinylController.java
@@ -81,8 +81,8 @@ public class VinylController {
     public ResponseEntity<Map<String, String>> delete(
             @PathVariable("id") Integer id) {
 
-        var vinyl = vinylService.delete(id);
+        vinylService.delete(id);
 
-        return ResponseEntity.ok(vinyl);
+        return ResponseEntity.ok().body(Map.of("message", "Vinyl Data Has Been Deleted"));
     }
 }

--- a/src/main/java/com/task/lecture9/repository/mapper/VinylMapper.java
+++ b/src/main/java/com/task/lecture9/repository/mapper/VinylMapper.java
@@ -2,6 +2,7 @@ package com.task.lecture9.repository.mapper;
 
 import com.task.lecture9.dto.VinylDto;
 import com.task.lecture9.repository.entity.Vinyl;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -36,4 +37,7 @@ public interface VinylMapper {
             "WHERE id=#{id}"
     )
     void update(Integer id, VinylDto vinylDto);
+
+    @Delete("DELETE FROM vinyl WHERE id=#{id}")
+    void delete(Integer id);
 }

--- a/src/main/java/com/task/lecture9/service/VinylService.java
+++ b/src/main/java/com/task/lecture9/service/VinylService.java
@@ -4,7 +4,6 @@ import com.task.lecture9.dto.VinylDto;
 import com.task.lecture9.repository.entity.Vinyl;
 
 import java.util.List;
-import java.util.Map;
 
 public interface VinylService {
     List<Vinyl> findAll();
@@ -15,5 +14,5 @@ public interface VinylService {
 
     Vinyl update(Integer id, VinylDto vinylDto) throws Exception;
 
-    Map<String, String> delete(Integer id);
+    void delete(Integer id);
 }

--- a/src/main/java/com/task/lecture9/service/VinylService.java
+++ b/src/main/java/com/task/lecture9/service/VinylService.java
@@ -4,6 +4,7 @@ import com.task.lecture9.dto.VinylDto;
 import com.task.lecture9.repository.entity.Vinyl;
 
 import java.util.List;
+import java.util.Map;
 
 public interface VinylService {
     List<Vinyl> findAll();
@@ -13,4 +14,6 @@ public interface VinylService {
     int insert(VinylDto vinylDto);
 
     Vinyl update(Integer id, VinylDto vinylDto) throws Exception;
+
+    Map<String, String> delete(Integer id);
 }

--- a/src/main/java/com/task/lecture9/service/VinylServiceImpl.java
+++ b/src/main/java/com/task/lecture9/service/VinylServiceImpl.java
@@ -7,6 +7,7 @@ import com.task.lecture9.repository.mapper.VinylMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -42,5 +43,12 @@ public class VinylServiceImpl implements VinylService {
         vinylMapper.update(id, vinylDto);
         var vinyl = vinylMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("更新するデータがありません"));
         return vinyl;
+    }
+
+    @Override
+    public Map<String, String> delete(Integer id) {
+        var vinyl = vinylMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("削除するデータがありません"));
+        vinylMapper.delete(id);
+        return Map.of("message", "Vinyl Data Has Been Deleted");
     }
 }

--- a/src/main/java/com/task/lecture9/service/VinylServiceImpl.java
+++ b/src/main/java/com/task/lecture9/service/VinylServiceImpl.java
@@ -7,7 +7,6 @@ import com.task.lecture9.repository.mapper.VinylMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -46,9 +45,8 @@ public class VinylServiceImpl implements VinylService {
     }
 
     @Override
-    public Map<String, String> delete(Integer id) {
+    public void delete(Integer id) {
         var vinyl = vinylMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("削除するデータがありません"));
         vinylMapper.delete(id);
-        return Map.of("message", "Vinyl Data Has Been Deleted");
     }
 }

--- a/src/test/java/com/task/lecture9/repository/mapper/dbrider/VinylMapperTest.java
+++ b/src/test/java/com/task/lecture9/repository/mapper/dbrider/VinylMapperTest.java
@@ -138,4 +138,20 @@ class VinylMapperTest {
         );
         vinylMapper.update(1, vinylDto);
     }
+
+    @Test
+    @DataSet(value = "datasets/forUpdateVinyl.yml")
+    @Transactional
+    void 指定したidのVinylDataを正常に削除できること() {
+        vinylMapper.delete(1);
+        assertThat(vinylMapper.findById(1)).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/forUpdateVinyl.yml")
+    @Transactional
+    void 存在しないidで削除リクエストをした場合何も削除されないこと() {
+        vinylMapper.delete(10);
+        assertThat(vinylMapper.findAll()).contains(new Vinyl(1, "aa", "bb", "cc", "1999"));
+    }
 }

--- a/src/test/java/com/task/lecture9/service/VinylServiceImplTest.java
+++ b/src/test/java/com/task/lecture9/service/VinylServiceImplTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -190,8 +189,7 @@ class VinylServiceImplTest {
         doReturn(vinyl).when(vinylMapper).findById(8);
         doNothing().when(vinylMapper).delete(8);
 
-        Map<String, String> actual = vinylServiceImpl.delete(8);
-        assertThat(actual).isEqualTo(Map.of("message", "Vinyl Data Has Been Deleted"));
+        vinylServiceImpl.delete(8);
 
         verify(vinylMapper, times(1)).findById(8);
         verify(vinylMapper, times(1)).delete(8);

--- a/src/test/java/com/task/lecture9/service/VinylServiceImplTest.java
+++ b/src/test/java/com/task/lecture9/service/VinylServiceImplTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -180,5 +181,34 @@ class VinylServiceImplTest {
 
         verify(vinylMapper, times(1)).update(7, vinylDto);
         verify(vinylMapper, times(1)).findById(7);
+    }
+
+    @Test
+    void 指定したidのVinylDataを正常に削除できること() {
+        Optional<Vinyl> vinyl = Optional.of(new Vinyl(8, "aa", "bb", "cc", "1999"));
+
+        doReturn(vinyl).when(vinylMapper).findById(8);
+        doNothing().when(vinylMapper).delete(8);
+
+        Map<String, String> actual = vinylServiceImpl.delete(8);
+        assertThat(actual).isEqualTo(Map.of("message", "Vinyl Data Has Been Deleted"));
+
+        verify(vinylMapper, times(1)).findById(8);
+        verify(vinylMapper, times(1)).delete(8);
+    }
+
+    @Test
+    void 存在しないidで削除リクエストをした場合削除するデータがありませんと返されること() {
+        Optional<Vinyl> vinyl = Optional.of(new Vinyl(8, "aa", "bb", "cc", "1999"));
+
+        doReturn(Optional.empty()).when(vinylMapper).findById(10);
+
+        ResourceNotFoundException e =
+                assertThrows(ResourceNotFoundException.class, () -> {
+                    vinylServiceImpl.delete(10);
+                });
+        assertThat(e.getMessage()).isEqualTo("削除するデータがありません");
+
+        verify(vinylMapper, times(1)).findById(10);
     }
 }

--- a/src/test/java/integrationtest/VinylIntegrationTest.java
+++ b/src/test/java/integrationtest/VinylIntegrationTest.java
@@ -339,4 +339,42 @@ public class VinylIntegrationTest {
                     "\"message\": {\"releaseYear\":[\"整数4桁で入力してください\"]}}", response, JSONCompareMode.STRICT);
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/forUpdateVinyl.yml")
+    @Transactional
+    void 指定したidのVinylDataを正常に削除できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/vinyls/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                "message":"Vinyl Data Has Been Deleted"
+                }
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/forUpdateVinyl.yml")
+    @Transactional
+    void 存在しないidで削除リクエストをした場合削除するデータがありませんと返されること() throws Exception {
+        try (MockedStatic<ZonedDateTime> zonedDateTimeMockedStatic = Mockito.mockStatic(ZonedDateTime.class)) {
+            zonedDateTimeMockedStatic.when(ZonedDateTime::now).thenReturn(zonedDataTime);
+
+            String response = mockMvc.perform(MockMvcRequestBuilders.delete("/vinyls/10"))
+                    .andExpect(MockMvcResultMatchers.status().isNotFound())
+                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+            JSONAssert.assertEquals("""
+                    {
+                    "timestamp":"2022-08-31T00:00+09:00[Asia/Tokyo]",
+                    "status":"404",
+                    "error":"Not Found",
+                    "message":"削除するデータがありません",
+                    "path":"/vinyls/10"
+                    }
+                    """, response, JSONCompareMode.STRICT);
+        }
+    }
 }


### PR DESCRIPTION
# PRの概要

- **DELETE機能を実装** be7d054c7590119f7338c1536eddb3b01c63447e
- **DELETE機能のテストを実装**
  - VinylMapperTest(Mapperテスト) e1b6ea82b65c455b0d498f86a6b179cf0891d640
  - VinylServiceImplTest(ServiceImplテスト) bc45ad5246aed9f19ab48206380fd76ad5b8e139
  - VinylIntegrationTest(結合テスト) c5a1fa3635197b8546774f40dee676a703721037

## DELETE機能実装の内容

- VinylMapper , VinylService , VinylServiceImpl , VinylControllerにそれぞれdeleteメソッドを追加
- VinylMapperTest , VinylServiceImpleTest , VinylIntegrationTestにそれぞれ削除テストを追加

## Postmanでの動作確認

<details>
<summary>1件削除した場合</summary>

![削除成功](https://user-images.githubusercontent.com/103630732/220654746-09062299-093b-4541-ad21-e714601418ce.png)
</details>

<details>
<summary>存在しないデータを削除しようとした場合</summary>

![存在しないデータを削除しようとした場合](https://user-images.githubusercontent.com/103630732/220655113-afb21049-bc03-454c-8b93-8f9720346231.png)
</details>